### PR TITLE
Configured gatsby to add "published" field to all markdown page nodes

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,15 +6,38 @@
 
 const path = require(`path`)
 const { createFilePath } = require(`gatsby-source-filesystem`)
+const { GraphQLBoolean } = require("gatsby/graphql")
+
+// This will set an additional field on our data nodes in our GQL Schema
+// The field will be "published" and will be a boolean
+// We query for this inside of our "createPages" API
+// In development, published will be set to true for all files.
+// In production, it'll be set to the opposite of the post's "draft" status...
+// in other words, any post with a draft:true will not be published
+exports.setFieldsOnGraphQLNodeType = ({ type }) => {
+  if (type.name === "MarkdownRemark") {
+    return {
+      published: {
+        type: GraphQLBoolean,
+        resolve: ({ frontmatter }) => {
+          if (process.env.NODE_ENV === "development") return true
+          return !frontmatter.draft
+        },
+      },
+    }
+  }
+  return {}
+}
 
 exports.createPages = async ({ actions, graphql }) => {
   const { createPage } = actions
 
   const result = await graphql(`
     query CreatePages {
-      allMarkdownRemark(filter: { frontmatter: { draft: { ne: true } } }) {
+      allMarkdownRemark {
         edges {
           node {
+            published
             fields {
               slug
             }
@@ -37,7 +60,10 @@ exports.createPages = async ({ actions, graphql }) => {
   }
 
   result.data.allMarkdownRemark.edges.forEach(({ node }) => {
-    console.log(`Creating page`, node.frontmatter.path)
+    if (!node.published) {
+      console.log(`SKIPPING (DRAFT):`, node.frontmatter.path)
+      return
+    }
     createPage({
       path: node.frontmatter.path,
       component: path.resolve(`src/templates/post.tsx`),


### PR DESCRIPTION
depending on whether or not there's a "draft" field in the frontmatter.

This lets us avoid building those pages and filter out the data inside
of our blog page.